### PR TITLE
chore:fix hyperlink for BigQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 - **[Minima](https://github.com/dmayboroda/minima)** - Local RAG (on-premises) with MCP server.
 - **[Jina Reader](https://github.com/wong2/mcp-jina-reader)** - Fetch the content of a remote URL as Markdown with Jina Reader.
 - **[any-chat-completions-mcp](https://github.com/pyroprompts/any-chat-completions-mcp)** - Chat with any other OpenAI SDK Compatible Chat Completions API, like Perplexity, Groq, xAI and more
-- **[BigQuery]([https://github.com/LucasHild/mcp-server-bigquery)** - BigQuery database integration with schema inspection and query capabilities
+- **[BigQuery](https://github.com/LucasHild/mcp-server-bigquery)** - BigQuery database integration with schema inspection and query capabilities
 
 ---
 


### PR DESCRIPTION
- Remove '[' from BigQuery link