### PR TITLE
Add entry for Windows CLI MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 - **[Jina Reader](https://github.com/wong2/mcp-jina-reader)** - Fetch the content of a remote URL as Markdown with Jina Reader.
 - **[any-chat-completions-mcp](https://github.com/pyroprompts/any-chat-completions-mcp)** - Chat with any other OpenAI SDK Compatible Chat Completions API, like Perplexity, Groq, xAI and more
 - **[BigQuery](https://github.com/LucasHild/mcp-server-bigquery)** - BigQuery database integration with schema inspection and query capabilities
+- **[Windows CLI](https://github.com/SimonB97/win-cli-mcp-server)** - MCP server for secure command-line interactions on Windows systems, enabling controlled access to PowerShell, CMD, and Git Bash shells.
 
 ---
 


### PR DESCRIPTION
Add entry for Windows CLI MCP Server to the README.md file.

* Add a new entry under the Community Servers section for the Windows CLI MCP Server.
* Include a link to the repository `[https://github.com/SimonB97/win-cli-mcp-server`](https://github.com/SimonB97/win-cli-mcp-server%60).