### PR TITLE
Add Metoro MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@
 - **[Data Exploration](https://github.com/reading-plus-ai/mcp-server-data-exploration)** - MCP server for autonomous data exploration on .csv-based datasets, providing intelligent insights with minimal effort.
 - **[CoinCap](https://github.com/QuantGeekDev/coincap-mcp)** - A MCP server that provides real-time cryptocurrency market data through CoinCap's public API without requiring authentication
 - **[Search1API](https://github.com/fatwang2/search1api-mcp)** - Search and crawl in one API
+- **[Metoro](https://github.com/metoro-io/metoro-mcp-server)** - Query and interact with Kubernetes environments monitored by Metoro
 
 ## Clients
 


### PR DESCRIPTION
Add Metoro - https://metoro.io/ - to the list of official integrations. We built an MCP server - https://github.com/metoro-io/metoro-mcp-server - for Metoro which allows MCP clients to directly query  the status of their Kubernetes clusters and all workloads running inside using natural language.