### PR TITLE
Added mcp-vegalite-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 - **[CoinCap](https://github.com/QuantGeekDev/coincap-mcp)** - A MCP server that provides real-time cryptocurrency market data through CoinCap's public API without requiring authentication
 - **[Search1API](https://github.com/fatwang2/search1api-mcp)** - Search and crawl in one API
 - **[Apple Shortcuts](https://github.com/recursechat/mcp-server-apple-shortcuts)** - An MCP Server Integration with Apple Shortcuts
+- **[Vega-Lite](https://github.com/isaacwasserman/mcp-vegalite-server)** - Generate visualizations from fetched data using the VegaLite format and renderer.
 
 ## Clients
 


### PR DESCRIPTION
The current list of community servers has lots of data sources but seems to be missing any sort of data visualization tools. While Claude Desktop natively renders Recharts visualizations well, it would be beneficial to have a way to produce charts in a canonical MCP-like way (especially for alternative clients). mcp-vegalite-server meets this requirement.