### PR TITLE
Update README.md - Add Everything Search to community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@
 - **[Snowflake](https://github.com/isaacwasserman/mcp-snowflake-server)** - Snowflake database integration with read/write capabilities and insight tracking
 - **[Clojars](https://github.com/Bigsy/Clojars-MCP-Server)** - Obtains latest dependency details for Clojure libraries.
 - **[Apple Notes](https://github.com/RafalWilinski/mcp-apple-notes)** - Talk with your Apple Notes
+- **[Everything Search](https://github.com/mamertofabian/mcp-everything-search)** - Fast Windows file search using Everything SDK
 
 ## Clients
 


### PR DESCRIPTION
Add mamertofabian/mcp-everything-search to community servers. This server provides:
- Fast file search capabilities using Everything SDK
- Windows-specific implementation
- Complements existing filesystem servers with specialized search functionality