### PR TITLE
Rootly MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@
 - **[Home Assistant](https://github.com/voska/hass-mcp)** - Interact with Home Assistant to control smart home devices, query states, manage automations, and troubleshoot your smart home setup.
 - **[Rootly-AI-Labs/Rootly-MCP-server](https://github.com/Rootly-AI-Labs/Rootly-MCP-server)** - MCP server for the incident management platform [Rootly](https://rootly.com/).
 
-
 ## Clients
 
 - **[mcp-cli](https://github.com/wong2/mcp-cli)** a cli inspector for MCP servers

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@
 - **[QGIS](https://github.com/jjsantos01/qgis_mcp)** - connects QGIS Desktop to Claude AI through the MCP. This integration enables prompt-assisted project creation, layer loading, code execution, and more.
 - **[Fibery](https://github.com/Fibery-inc/fibery-mcp-server)** - Perform queries and entity operations in your [Fibery](https://fibery.io) workspace.
 - **[Home Assistant](https://github.com/voska/hass-mcp)** - Interact with Home Assistant to control smart home devices, query states, manage automations, and troubleshoot your smart home setup.
+- **[Rootly-AI-Labs/Rootly-MCP-server](https://github.com/Rootly-AI-Labs/Rootly-MCP-server)** - MCP server for the incident management platform [Rootly](https://rootly.com/).
+
 
 ## Clients
 


### PR DESCRIPTION
PR to add Rootly MCP server, which allows responders to manage their incident directly in their IDE