### PR TITLE
Add Binary Ninja MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Backup](https://github.com/hexitex/MCP-Backup-Server)** - Add smart Backup ability to coding agents like Windsurf, Cursor, Cluade Coder, etc
 - **[BigQuery](https://github.com/LucasHild/mcp-server-bigquery)** (by LucasHild) - BigQuery database integration with schema inspection and query capabilities
 - **[BigQuery](https://github.com/ergut/mcp-bigquery-server)** (by ergut) - Server implementation for Google BigQuery integration that enables direct BigQuery database access and querying capabilities
+- **[Binary Ninja](https://github.com/fosdickio/binary_ninja_mcp)** - A Binary Ninja plugin, MCP server, and bridge that seamlessly integrates [Binary Ninja](https://binary.ninja) with your favorite MCP client.
 - **[Bluesky](https://github.com/keturiosakys/bluesky-context-server)** - integrates with Bluesky API to query and search feeds and posts.
 - **[Box](https://github.com/hmk/box-mcp-server)** - File access and search for Box.
 - **[bytebase/dbhub](https://github.com/bytebase/dbhub)** – 📇 Universal database MCP server supporting mainstream databases.


### PR DESCRIPTION
## Description
This PR adds a new entry for the Binary Ninja MCP server implementation.  It is useful for connecting Binary Ninja with your favorite MCP client to aid in reverse engineering of software binaries.

## References
- https://github.com/fosdickio/binary_ninja_mcp
- https://binary.ninja

- [X] Place the newly added server in the right position alphabetically.
