### PR TITLE
Add Apple Books MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[AniList](https://github.com/yuna0x0/anilist-mcp)** - AniList MCP server for accessing AniList API data
 - **[any-chat-completions-mcp](https://github.com/pyroprompts/any-chat-completions-mcp)** - Chat with any other OpenAI SDK Compatible Chat Completions API, like Perplexity, Groq, xAI and more
 - **[APISIX-MCP](https://github.com/api7/apisix-mcp)** - APISIX Model Context Protocol (MCP) server is used to bridge large language models (LLMs) with the APISIX Admin API, supporting querying and managing all resources in [Apache APISIX](https://github.com/apache/apisix).
+- **[Apple Books](https://github.com/vgnshiyer/apple-books-mcp)** - Transform your Apple Books to a queryable knowledge base.
 - **[Apple Notes](https://github.com/RafalWilinski/mcp-apple-notes)** - Talk with your Apple Notes
 - **[Apple Shortcuts](https://github.com/recursechat/mcp-server-apple-shortcuts)** - An MCP Server Integration with Apple Shortcuts
 - **[Backup](https://github.com/hexitex/MCP-Backup-Server)** - Add smart Backup ability to coding agents like Windsurf, Cursor, Cluade Coder, etc


### PR DESCRIPTION
The Apple Books MCP server bridges the gap between your personal reading journey and AI capabilities by transforming static book collections into interactive knowledge repositories.

This server empowers readers

* to summarize highlights with a simple prompt
* search annotations by color-coding systems
* organize sprawling libraries by genre
* receive personalized book recommendations
* perform cross-book analysis on related topics. And much more.

By eliminating the manual effort traditionally required to manage reading insights, it creates a interface between your accumulated literary wisdom and conversational AI. For academics, lifelong learners, and casual readers alike, this integration transforms Apple Books from a mere content container into an accessible, queryable knowledge base that evolves alongside your reading habits.
