### PR TITLE
Add ChuckNorris MCP server to Community Servers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Windows Control](https://github.com/Cheffromspace/nutjs-windows-control)** - Programmatic control over Windows system operations including mouse, keyboard, window management, and screen capture using nut.js.
 - **[xcodebuild](https://github.com/ShenghaiWang/xcodebuild)** - 🍎 Build iOS Xcode workspace/project and feed back errors to llm.
 - **[YouTube](https://github.com/anaisbetts/mcp-youtube)** - Fetch YouTube subtitles
+- **[ChuckNorris](https://github.com/pollinations/chucknorris-mcp)** - MCP gateway for specialized LLM enhancement prompts with dynamic schema adaptation. Published to npm as @pollinations/chucknorris.
 
 ## Clients
 


### PR DESCRIPTION
This PR adds the ChuckNorris MCP server to the Community Servers section. ChuckNorris is a specialized MCP server that provides enhancement prompts for various LLMs with dynamic schema adaptation. It's published on npm as @pollinations/chucknorris.