### PR TITLE
Add Google Keep MCP Server (keep-mcp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Gentoro](https://github.com/gentoro-GT/mcp-nodejs-server)** - Gentoro generates MCP Servers based on OpenAPI specifications.
 - **[godoc-mcp-server](https://github.com/yikakia/godoc-mcp-server)** - MCP server to provide golang packages and their information from pkg.go.dev
 - **[Godot MCP](https://github.com/Coding-Solo/godot-mcp)** - MCP server for interacting with the Godot game engine, providing tools for editing, running, debugging, and managing scenes in Godot projects.
+- **[Google Keep](https://github.com/feuerdev/keep-mcp)** - Read, create, update and delete Google Keep notes.
 - **[Google News](https://github.com/ChanMeng666/server-google-news)** - Google News search capabilities with automatic topic categorization and multi-language support via SerpAPI integration.
 - **[Google Search Console](https://github.com/ahonn/mcp-server-gsc)** - A Model Context Protocol (MCP) server providing access to Google Search Console.
 - **[gotoolkits/wecombot](https://github.com/gotoolkits/mcp-wecombot-server.git)** - 🏎️ ☁️ An MCP server application that sends various types of messages to the WeCom group robot.


### PR DESCRIPTION
Added the [feuerdev/keep-mcp](https://github.com/feuerdev/keep-mcp) server for [Google Keep](https://keep.google.com/) integration.

Thank you for maintaining this repository!

- [x] Place the newly added server in the right position alphabetically.