### PR TITLE
Proposal to add community MCP Slack server to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Rootly-AI-Labs/Rootly-MCP-server](https://github.com/Rootly-AI-Labs/Rootly-MCP-server)** - MCP server for the incident management platform [Rootly](https://rootly.com/).
 - **[Search1API](https://github.com/fatwang2/search1api-mcp)** - Search and crawl in one API
 - **[SearXNG](https://github.com/ihor-sokoliuk/mcp-searxng)** - A Model Context Protocol Server for [SearXNG](https://docs.searxng.org)
+- **[Slack](https://github.com/korotovsky/slack-mcp-server)** - The most powerful MCP server for Slack Workspaces. This integration supports both Stdio and SSE transports, proxy settings and does not require any permissions or bots being created or approved by Workspace admins 😏.
 - **[Snowflake](https://github.com/isaacwasserman/mcp-snowflake-server)** - Snowflake database integration with read/write capabilities and insight tracking
 - **[Skyvern](https://github.com/Skyvern-AI/skyvern/tree/main/integrations/mcp)** - MCP Server to let Claude / your AI control the browser
 - **[TikTok](https://github.com/Seym0n/tiktok-mcp)** - TikTok integration for getting post details and video subtitles


### PR DESCRIPTION
Added community MCP Slack server to the README

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Unlike the "reference server" version of the Slack MCP, proposed MCP server supports stdio and sse transports, proxy settings and in my opinion, most important it does not require bot/apps being created in the Slack Workspace that will require approvals so it is possible to setup MCP server fully for yourself on behalf your own account.
