### PR TITLE
Add OpenAPI Schema Explorer MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[NPM Search](https://github.com/btwiuse/npm-search-mcp-server)** - Search for npm packages
 - **[Obsidian](https://github.com/MarkusPfundstein/mcp-obsidian)** - Interacting with Obsidian via REST API
 - **[OpenAI](https://github.com/pierrebrunelle/mcp-server-openai)** - Query OpenAI models directly from Claude using MCP protocol
+- **[OpenAPI Schema Explorer](https://github.com/kadykov/mcp-openapi-schema-explorer)** - Token-efficient access to OpenAPI/Swagger specs via MCP Resources
 - **[Pandoc](https://github.com/vivekVells/mcp-pandoc)** - MCP server for seamless document format conversion using Pandoc, supporting Markdown, HTML, and plain text, with other formats like PDF, csv and docx in development.
 - **[PBS API](https://github.com/matthewdcage/pbs-mcp-server)** - 🐍 ☁️ Access Australian Pharmaceutical Benefits Scheme data for medicine information, pricing, and availability. Built with Python and FastAPI.
 - **[Perplexity](https://github.com/tanigami/mcp-server-perplexity)** - Interacting with Perplexity


### PR DESCRIPTION
**Reason for Addition:**

Working with large OpenAPI or Swagger specifications can quickly consume context window limits. This server solves that problem by providing **token-efficient access** to API specs via MCP Resources.

Instead of loading the entire file, users can interactively explore API paths, operations, and components using intuitive URIs (`openapi://...`). It supports local files and remote URLs, automatically handles Swagger v2 conversion, and transforms internal references into clickable links, making API understanding and exploration significantly faster and more context-friendly.

- [x] Place the newly added server in the right position alphabetically.