### PR TITLE
Add CRIC Wuye AI official MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Official integrations are maintained by companies building production ready MCP 
 - **[Context 7](https://github.com/upstash/context7-mcp)** - Context7 MCP - Up-to-date Docs For Any Cursor Prompt
 - **[Convex](https://stack.convex.dev/convex-mcp-server)** - Introspect and query your apps deployed to Convex.
 - **[Couchbase](https://github.com/Couchbase-Ecosystem/mcp-server-couchbase)** - Interact with the data stored in Couchbase clusters using natural language.
+- **[CRIC Wuye AI](https://github.com/wuye-ai/mcp-server-wuye-ai)** - Interact with capabilities of the CRIC Wuye AI platform, an intelligent assistant specifically for the property management industry.
 - **[Cua](https://github.com/trycua/cua/tree/main/libs/mcp-server)** - MCP server for the Computer-Use Agent (CUA), allowing you to run CUA through Claude Desktop or other MCP clients.
 - **[Currents](https://github.com/currents-dev/currents-mcp)** - Enable AI Agents to fix Playwright test failures reported to [Currents](https://currents.dev).
 - **[Dart](https://github.com/its-dart/dart-mcp-server)** - Interact with task, doc, and project data in [Dart](https://itsdart.com), an AI-native project management tool


### PR DESCRIPTION
- [x] Place the newly added server in the right position alphabetically.

Add CRIC Wuye AI official MCP Server. 

**CRIC Wuye AI** (CRIC物业AI) is an intelligent assistant developed by [CRIC](http://www.cricchina.com/) specifically for the property management industry. It was [officially launched](https://mp.weixin.qq.com/s/GC4V1M6N199Ay2f3kZan_Q) on April 25, 2025.

*P.S. CRIC is the top Industry Research & Database Provider in Real Estate Sector of China. Wuye (物业) means Property Management in Chinese.*

Leveraging a combination of industry knowledge base construction, multimodal large models, and RAG technology, **CRIC Wuye AI** integrates five core capability modules: **Industry Research**, **Laws & Regulations**, **Community Governance**, **Project Operations**, and **Content Writing**. It also expands into two smart agents focused on **News & Public Opinion** and **Talent Training** based on vertical industry knowledge.

**CRIC Wuye AI MCP Server** is a server-side implementation based on the [Model Context Protocol](https://modelcontextprotocol.github.io/), delivering part of the atomic capabilities of the **CRIC Wuye AI** platform.
