### PR TITLE
Update to README.md with a reference to the official Reexpress AI MCP…

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Official integrations are maintained by companies building production ready MCP 
 - **[RAD Security](https://github.com/rad-security/mcp-server)** - Interact with the RAD Security platform which provides AI-powered security insights for Kubernetes and cloud environments.
 - **[Ramp](https://github.com/ramp-public/ramp-mcp)** - Interact with [Ramp](https://ramp.com)'s Developer API to run analysis on your spend and gain insights leveraging LLMs
 - **[Raygun](https://github.com/MindscapeHQ/mcp-server-raygun)** - Interact with your crash reporting and real using monitoring data on your Raygun account
+- **[Reexpress](https://github.com/ReexpressAI/reexpress_mcp_server)** - Enable Similarity-Distance-Magnitude statistical verification for your search, software, and data science workflows
 - **[Rember](https://github.com/rember/rember-mcp)** - Create spaced repetition flashcards in [Rember](https://rember.com) to remember anything you learn in your chats
 - **[Riza](https://github.com/riza-io/riza-mcp)** - Arbitrary code execution and tool-use platform for LLMs by [Riza](https://riza.io)
 - **[Root Signals](https://github.com/root-signals/root-signals-mcp)** - Equip AI agents with evaluation and self-improvement capabilities with [Root Signals](https://www.rootsignals.ai/)


### PR DESCRIPTION
… Server

## Description
This adds a reference to the official Reexpress AI MCP Server in README.md.

## Server Details
The Reexpress MCP Server is a drop-in solution to add state-of-the-art statistical verification to your complex LLM pipelines, as well as your everyday use of LLMs for search and QA for software development and data science settings. It's the first reliable, statistically robust AI second opinion for your AI workflows.

In addition to providing you (the user) with a principled estimate of confidence in the output given your instructions, Claude (or other tool-calling LLMs) itself can use the verification output to progressively refine its answer, determine if it needs additional outside resources or tools, or has reached an impasse and needs to ask you for further clarification or information.

The current version works on Apple silicon Macs running macOS 15 (Sequoia). The server ensembles external LLM APIs with an on-device PyTorch model and an updatable local dense database, over which it calculates a well-calibrated Similarity-Distance-Magnitude estimator.

## Motivation and Context
Given the wide-spread use of LLMs in real-world settings, a principled and robust approach for uncertainty quantification over the output of such models is critical. Here, the estimator is relative to the binary classification decision of whether the response addresses the user's question or instruction. This is useful, for example, to constrain hallucinations (up to a suitable probabilisitic threshold for a given task), and to route conditional branching decisions in complex agent-based pipelines.

## Checklist
- [X] Place the newly added server in the right position alphabetically.
