### PR TITLE
Add Google Cloud Run

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Official integrations are maintained by companies building production ready MCP 
 - **[GitHub](https://github.com/github/github-mcp-server)** - GitHub's official MCP Server
 - **[Gitee](https://github.com/oschina/mcp-gitee)** - Gitee API integration, repository, issue, and pull request management, and more.
 - **[Globalping](https://github.com/jsdelivr/globalping-mcp-server)** - Network access with the ability to run commands like ping, traceroute, mtr, http, dns resolve.
+- **[Google Cloud Run](https://github.com/GoogleCloudPlatform/cloud-run-mcp)** Official MCP Server to deploy to [Google Cloud Run](https://cloud.google.com/run).
 - **[gotoHuman](https://github.com/gotohuman/gotohuman-mcp-server)** - Human-in-the-loop platform - Allow AI agents and automations to send requests for approval to your [gotoHuman](https://www.gotohuman.com) inbox.
 - **[Grafana](https://github.com/grafana/mcp-grafana)** - Search dashboards, investigate incidents and query datasources in your Grafana instance
 - **[Graphlit](https://github.com/graphlit/graphlit-mcp-server)** - Ingest anything from Slack to Gmail to podcast feeds, in addition to web crawling, into a searchable [Graphlit](https://www.graphlit.com) project.


### PR DESCRIPTION
Include link to Google Cloud Run's official MCP server

- [x] Place the newly added server in the right position alphabetically.
