### PR TITLE
Added WayStation server to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Official integrations are maintained by companies building production ready MCP 
 - **[VeyraX](https://github.com/VeyraX/veyrax-mcp)** - Single tool to control all 100+ API integrations, and UI components
 - **[VideoDB](https://github.com/video-db/agent-toolkit/tree/main/modelcontextprotocol)** - Server for advanced AI-driven video editing, semantic search, multilingual transcription, generative media, voice cloning, and content moderation.
 - **[VISO TRUST](https://github.com/visotrust/viso-mcp-server)** - Access and manage your VISO TRUST third-party risk program directly through your AI assistant.
+- **[WayStation](https://waystation.ai/connect/mcp-server)** — A universal remote MCP server that connects to popular productivity tools such as Notion, Monday, AirTable, and many more.
 - **[Webflow](https://github.com/webflow/mcp-server)** - Interact with Webflow APIs to list and edit your site and CMS data.
 - **[WebScraping.AI](https://github.com/webscraping-ai/webscraping-ai-mcp-server)** - Interact with **[WebScraping.AI](https://WebScraping.AI)** for web data extraction and scraping.
 - **[Xero](https://github.com/XeroAPI/xero-mcp-server)** - Interact with the accounting data in your business using our official MCP server


### PR DESCRIPTION
Please consider adding WayStation to the list of remote MCP servers. WayStation MCP seamlessly connects Claude (and other clients) to a broad range of productivity tools, including Notion, Monday, AirTable, etc.

A few notes:
- WayStation MCP supports both Streamable HTTPS and SSE transports
- The default endpoint at https://waystation.ai/mcp does transport negotiation and authorization if necessary
- WayStation also provides preauthenticated individual endpoints like https://waystation.ai/mcp/Iddq66dIdkfARDNb3K. Any registered user can get one at https://waystation.ai/connect/mcp-server/guide
- The server was tested with Claude, Cursor, Cline, WindSurf, and MCP-remote

Thanks for consideration!