### PR TITLE
Add SchemaFlow MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Playwright MCP Server](https://github.com/executeautomation/mcp-playwright)** - An MCP server using Playwright for browser automation and webscrapping
 - **[QGIS](https://github.com/jjsantos01/qgis_mcp)** - connects QGIS Desktop to Claude AI through the MCP. This integration enables prompt-assisted project creation, layer loading, code execution, and more.
 - **[Rootly-AI-Labs/Rootly-MCP-server](https://github.com/Rootly-AI-Labs/Rootly-MCP-server)** - MCP server for the incident management platform [Rootly](https://rootly.com/).
+- **[SchemaFlow](https://github.com/CryptoRadi/schemaflow-mcp-server)** - Real-time PostgreSQL & Supabase database schema access for AI-IDEs via Model Context Protocol. Provides live database context through secure SSE connections with three powerful tools: get_schema, analyze_database, and check_schema_alignment. [SchemaFlow](https://schemaflow.dev)
 - **[Search1API](https://github.com/fatwang2/search1api-mcp)** - Search and crawl in one API
 - **[SearXNG](https://github.com/ihor-sokoliuk/mcp-searxng)** - A Model Context Protocol Server for [SearXNG](https://docs.searxng.org)
 - **[Secure Fetch](https://github.com/appsec-innovation-labs/secure-mcp-fetch)** - Secure fetch to prevent access to local resources


### PR DESCRIPTION
## SchemaFlow MCP Server

Adding SchemaFlow to the awesome MCP servers list.

**What it does:**
- Provides real-time PostgreSQL & Supabase schema access via MCP
- Enables AI-IDEs to get live database context for smarter code generation
- Supports Server-Sent Events (SSE) for real-time updates

**Links:**
- GitHub: https://github.com/CryptoRadi/schemaflow-mcp-server
- Website: https://schemaflow.dev
- Documentation: https://schemaflow.dev/mcp-guide

**Supported AI-IDEs:**
- Cursor
- Windsurf  
- VS Code + Cline

This server helps developers by providing their AI coding assistants with up-to-date database schema information, enabling more accurate code generation and database queries.