### PR TITLE
Add official Pearl MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Official integrations are maintained by companies building production ready MCP 
 - **[OP.GG](https://github.com/opgginc/opgg-mcp)** - Access real-time gaming data across popular titles like League of Legends, TFT, and Valorant, offering champion analytics, esports schedules, meta compositions, and character statistics.
 - **[Oxylabs](https://github.com/oxylabs/oxylabs-mcp)** - Scrape websites with Oxylabs Web API, supporting dynamic rendering and parsing for structured data extraction.
 - **[PayPal](https://github.com/paypal/agent-toolkit)** - The PayPal Model Context Protocol server allows you to integrate with PayPal APIs through function calling. This protocol supports various tools to interact with different PayPal services.
+- **[Pearl](https://mcp.pearl.com)** - Official MCP Server to interact with Pearl API. Connect your AI Agents with 12,000+ certified experts instantly.
 - **[Perplexity](https://github.com/ppl-ai/modelcontextprotocol)** - An MCP server that connects to Perplexity's Sonar API, enabling real-time web-wide research in conversational AI.
 - **[PGYER](https://github.com/PGYER/pgyer-mcp-server)** - MCP Server for [PGYER](https://www.pgyer.com/) platform, supports uploading, querying apps, etc.
 - **[Plane](https://github.com/makeplane/plane-mcp-server)** - The official Plane MCP server provides integration with Plane APIs, enabling full AI automation of Plane projects, work items, cycles and more.


### PR DESCRIPTION
This PR adds the official Pearl MCP Server to the list of available MCP-compatible servers. 
The Pearl MCP Server provides a standardized interface to access Pearl's unique Expert-as-a-Service platform, allowing LLM clients to invoke real-time assistance from certified human experts across a broad range of categories.

Server Details
Server: https://mcp.pearl.com/mcp
Changes to: README – added a new server entry under Official MCP Servers

The Pearl MCP Server expands the ecosystem of MCP-compatible tools by introducing a distinctive type of tool: humans. Unlike traditional MCP implementations that connect to APIs or code snippets, this server enables AI agents (e.g., Claude, Cursor, GitHub Copilot) to interact with domain-specific human experts in real time. It offers a robust path for tasks that require nuanced judgment, contextual understanding, or legal, medical, and technical advice from certified professionals.