### PR TITLE
Add @bldbl/mcp - Buildable AI Development Platform MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Official integrations are maintained by companies building production ready MCP 
 - **[Browserbase](https://github.com/browserbase/mcp-server-browserbase)** - Automate browser interactions in the cloud (e.g. web navigation, data extraction, form filling, and more)
 - **[BrowserStack](https://github.com/browserstack/mcp-server)** – Bring the full power of BrowserStack’s [Test Platform](https://www.browserstack.com/test-platform) to your AI tools, making testing faster and easier for every developer and tester on your team.
 - **[Bucket](https://github.com/bucketco/bucket-javascript-sdk/tree/main/packages/cli#model-context-protocol)** - Flag features, manage company data, and control feature access using [Bucket](https://bucket.co)
+- **[Buildable](https://github.com/chunkydotdev/bldbl-mcp)** - Official MCP server for Buildable AI-powered development platform. Enables AI assistants to manage tasks, track progress, get project context, and collaborate with humans on software projects.
 - **[Buildkite](https://github.com/buildkite/buildkite-mcp-server)** - Manage [Buildkite](https://buildkite.com) pipelines and builds.
 - **[Campertunity](https://github.com/campertunity/mcp-server)** - Search campgrounds around the world on campertunity, check availability, and provide booking links.
 - **[Chargebee](https://github.com/chargebee/agentkit/tree/main/modelcontextprotocol)** - MCP Server that connects AI agents to [Chargebee platform](https://www.chargebee.com).


### PR DESCRIPTION
- [x] Place the newly added server in the right position alphabetically.

# Summary
Adding **@bldbl/mcp** to the Official Servers section - a production-ready MCP server that enables AI assistants to work directly with software development projects.

This MCP server fills a specific gap in the ecosystem by providing structured AI development workflows, making it a valuable addition to the curated list.
