### PR TITLE
Add calcom community server

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[bytebase/dbhub](https://github.com/bytebase/dbhub)** – 📇 Universal database MCP server supporting mainstream databases.\
 - **[Calculator](https://github.com/githejie/mcp-server-calculator)** - This server enables LLMs to use calculator for precise numerical calculations.
 - **[CalDAV MCP](https://github.com/dominik1001/caldav-mcp)** - A CalDAV MCP server to expose calendar operations as tools for AI assistants.
+- **[Danielpeter-99/calcom-mcp](https://github.com/Danielpeter-99/calcom-mcp)** - MCP server for [Calcom](https://cal.com/) (Also known as [Cal.com](https://cal.com/)). Manage event types, create bookings, and access Cal.com scheduling data through LLMs.
 - **[Career Site Jobs](https://apify.com/fantastic-jobs/career-site-job-listing-api/api/mcp)** - A MCP server to retrieve up-to-date jobs from company career sites.
 - **[Canvas LMS](https://github.com/ahnopologetic/canvas-lms-mcp)** - MCP server for easy access to education data through your Canvas LMS instance.
 - **[Chaitin IP Intelligence](https://github.com/co0ontty/chaitin-ip-intelligence-search-tool)** - Search for IP addresses using Chaitin's IP Intelligence API.


### PR DESCRIPTION
The server currently provides the following tools for LLM interaction:

- get_api_status(): Check if the Cal.com API key is configured in the environment. Returns a string indicating the status.
- list_event_types(): Fetch a list of all event types from Cal.com for the authenticated account. Returns a dictionary with the list of - - event types or an error message.
- get_bookings(...): Fetch a list of bookings from Cal.com, with optional filters (event_type_id, user_id, status, date_from, date_to, limit). Returns a dictionary with the list of bookings or an error message.
- create_booking(...): Create a new booking in Cal.com for a specific event type and attendee. Requires parameters like start_time, attendee details, and event type identifiers. Returns a dictionary with booking details or an error message.
- list_schedules(...): List all schedules available to the authenticated user or for a specific user/team. Optional filters: user_id, team_id, limit. Returns a dictionary with the list of schedules or an error message.
- list_teams(...): List all teams available to the authenticated user. Optional filter: limit. Returns a dictionary with the list of teams or an error message.
- list_users(...): List all users available to the authenticated account. Optional filter: limit. Returns a dictionary with the list of users or an error message.
- list_webhooks(...): List all webhooks configured for the authenticated account. Optional filter: limit. Returns a dictionary with the list of webhooks or an error message.

- [✅] Place the newly added server in the right position alphabetically.
