### PR TITLE
Add Probe.dev MCP Server to Official Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Official integrations are maintained by companies building production ready MCP 
 - **[Playwright](https://github.com/microsoft/playwright-mcp)** - Playwright MCP server
 - **[Plugged.in](https://github.com/VeriTeknik/pluggedin-mcp-proxy)** - A comprehensive proxy that combines multiple MCP servers into a single MCP. It provides discovery and management of tools, prompts, resources, and templates across servers, plus a playground for debugging when building MCP servers.
 - **[Powerdrill](https://github.com/powerdrillai/powerdrill-mcp)** - An MCP server that provides tools to interact with Powerdrill datasets, enabling smart AI data analysis and insights.
+- **[Probe.dev](https://mcp.probe.dev)** - Professional media analysis and validation MCP server with FFprobe, MediaInfo, and comprehensive reporting capabilities.
 - **[QA Sphere](https://github.com/Hypersequent/qasphere-mcp)** - Integration with [QA Sphere](https://qasphere.com/) test management system, enabling LLMs to discover, summarize, and interact with test cases directly from AI-powered IDEs
 - **[Qdrant](https://github.com/qdrant/mcp-server-qdrant/)** - Implement semantic memory layer on top of the Qdrant vector search engine
 - **[RAD Security](https://github.com/rad-security/mcp-server)** - Interact with the RAD Security platform which provides AI-powered security insights for Kubernetes and cloud environments.


### PR DESCRIPTION
- Professional media analysis and validation MCP server
- Supports FFprobe, MediaInfo integration
- Comprehensive reporting capabilities
- Production-ready MCP implementation
- Hosted at https://mcp.probe.dev

- [x] Place the newly added server in the right position alphabetically.
