### PR TITLE
Add Cricket MCP Server to Community Servers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Official integrations are maintained by companies building production ready MCP 
 - **[Coresignal](https://github.com/Coresignal-com/coresignal-mcp/)** - Access comprehensive B2B data on companies, employees, and job postings for your LLMs and AI workflows.
 - **[Couchbase](https://github.com/Couchbase-Ecosystem/mcp-server-couchbase)** - Interact with the data stored in Couchbase clusters using natural language.
 - **[CRIC Wuye AI](https://github.com/wuye-ai/mcp-server-wuye-ai)** - Interact with capabilities of the CRIC Wuye AI platform, an intelligent assistant specifically for the property management industry.
+- **[Cricket MCP Server](https://github.com/tarun7r/cricket-mcp-server)** - A MCP server for fetching cricket data from Cricbuzz, including player statistics, live match scores, upcoming schedules, and the latest news.
 - **[Cua](https://github.com/trycua/cua/tree/main/libs/mcp-server)** - MCP server for the Computer-Use Agent (CUA), allowing you to run CUA through Claude Desktop or other MCP clients.
 - **[Currents](https://github.com/currents-dev/currents-mcp)** - Enable AI Agents to fix Playwright test failures reported to [Currents](https://currents.dev).
 - **[Cycode](https://github.com/cycodehq/cycode-cli#mcp-command-experiment)** - Boost security in your dev lifecycle via SAST, SCA, Secrets & IaC scanning with [Cycode](https://cycode.com/).


### PR DESCRIPTION
## Description
Add Cricket MCP Server to Community Servers list in README. Cricket MCP Server is a Model Context Protocol server that enables AI agents to fetch cricket data from Cricbuzz, including player statistics, live match scores, upcoming schedules, and the latest news.

## Motivation and Context
This server provides comprehensive cricket data access for AI agents, filling a gap in sports data availability within the MCP ecosystem. It offers real-time match information and historical statistics for cricket enthusiasts and developers.

## How Has This Been Tested?
- Server tested with Claude Desktop and other MCP clients
- Confirmed all tools function correctly (player stats, live scores, schedules, news)
- Error handling tested for various scenarios