### PR TITLE
Add Cloudbet Sports MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Official integrations are maintained by companies building production ready MCP 
 - **[CircleCI](https://github.com/CircleCI-Public/mcp-server-circleci)** - Enable AI Agents to fix build failures from CircleCI.
 - **[ClickHouse](https://github.com/ClickHouse/mcp-clickhouse)** - Query your [ClickHouse](https://clickhouse.com/) database server.
 - **[Cloudflare](https://github.com/cloudflare/mcp-server-cloudflare)** - Deploy, configure & interrogate your resources on the Cloudflare developer platform (e.g. Workers/KV/R2/D1)
+- **[Cloudbet](https://github.com/cloudbet/sports-mcp-server)** – Structured sports and esports data via Cloudbet API: fixtures, live odds, stake limits, and markets.
 - **[CoinGecko](https://docs.coingecko.com/reference/mcp-server/)** - Official [CoinGecko API](https://www.coingecko.com/en/api) MCP Server for Crypto Price & Market Data, across 200+ blokchain networks and 8M+ tokens. 
 - **[Comet Opik](https://github.com/comet-ml/opik-mcp)** - Query and analyze your [Opik](https://github.com/comet-ml/opik) logs, traces, prompts and all other telemtry data from your LLMs in natural language.
 - **[Context 7](https://github.com/upstash/context7-mcp)** - Context7 MCP - Up-to-date Docs For Any Cursor Prompt


### PR DESCRIPTION
Adds [cloudbet/sports-mcp-server](https://github.com/cloudbet/sports-mcp-server), a Go-based MCP server that provides access to structured sports and esports data.

Key features:
* Supports querying for fixtures, odds, stake limits, and market data
* Supports football, basketball, tennis, MMA, etc. and esports
* Implements fuzzy matching for league query resolution
* **No API key required — free and anonymous access**
