### PR TITLE
Add Mercado Libre's official MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Official integrations are maintained by companies building production ready MCP 
 - **[Mastra/mcp-docs-server](https://github.com/mastra-ai/mastra/tree/main/packages/mcp-docs-server)** - Provides AI assistants with direct access to Mastra.ai's complete knowledge base.
 - **[MCP Toolbox for Databases](https://github.com/googleapis/genai-toolbox)** - Open source MCP server specializing in easy, fast, and secure tools for Databases.
 - **[Meilisearch](https://github.com/meilisearch/meilisearch-mcp)** - Interact & query with Meilisearch (Full-text & semantic search API)
+- **[Mercado Libre](https://mcp.mercadolibre.com/)** - Mercado Libre's official MCP server, offering tools to interact with our marketplace, simplifying tasks and product integration.
 - **[Mercado Pago](https://mcp.mercadopago.com/)** - Mercado Pago's official MCP server, offering tools to interact with our API, simplifying tasks and product integration.
 - **[Metoro](https://github.com/metoro-io/metoro-mcp-server)** - Query and interact with kubernetes environments monitored by Metoro
 - **[Milvus](https://github.com/zilliztech/mcp-server-milvus)** - Search, Query and interact with data in your Milvus Vector Database.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Official integrations are maintained by companies building production ready MCP 
 - **[Mastra/mcp-docs-server](https://github.com/mastra-ai/mastra/tree/main/packages/mcp-docs-server)** - Provides AI assistants with direct access to Mastra.ai's complete knowledge base.
 - **[MCP Toolbox for Databases](https://github.com/googleapis/genai-toolbox)** - Open source MCP server specializing in easy, fast, and secure tools for Databases.
 - **[Meilisearch](https://github.com/meilisearch/meilisearch-mcp)** - Interact & query with Meilisearch (Full-text & semantic search API)
+- **[Mercado Pago](https://mcp.mercadopago.com/)** - Mercado Pago's official MCP server, offering tools to interact with our API, simplifying tasks and product integration.
 - **[Metoro](https://github.com/metoro-io/metoro-mcp-server)** - Query and interact with kubernetes environments monitored by Metoro
 - **[Milvus](https://github.com/zilliztech/mcp-server-milvus)** - Search, Query and interact with data in your Milvus Vector Database.
 - **[MotherDuck](https://github.com/motherduckdb/mcp-server-motherduck)** - Query and analyze data with MotherDuck and local DuckDB


### PR DESCRIPTION
## Description
Add official Mercado Libre MCP Server (http://mcp.mercadolibre.com/).

## Server Details
Add new official MCP Server for Mercado Libre, to enhance developer experience integrating with Mercado Libre solutions.
Server is hosted remotely by Mercadolibre supporting new Streamable HTTP Transport.
Details on how to connect to the server and example use cases are provided in [Mercado Libre's MCP Server doc site](http://mcp.mercadolibre.com/).

## Motivation and Context
Provide official MCP Server for Mercado Libre to enhance developers experience integrating with this platform.

## How Has This Been Tested?
Integration with the server was tested from several clients, including: Cursor, Windsurf, Cline and Claude Desktop.

- [x] Place the newly added server in the right position alphabetically.
