### PR TITLE
Add Project Manager MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[PiAPI](https://github.com/apinetwork/piapi-mcp-server)** - PiAPI MCP server makes user able to generate media content with Midjourney/Flux/Kling/Hunyuan/Udio/Trellis directly from Claude or any other MCP-compatible apps.
 - **[PiloTY](https://github.com/yiwenlu66/PiloTY)** - AI pilot for PTY operations that enables agents to control interactive terminals with stateful sessions, SSH connections, and background process management
 - **[Playwright MCP Server](https://github.com/executeautomation/mcp-playwright)** - An MCP server using Playwright for browser automation and webscrapping
+- **[Project Manager](https://github.com/croffasia/mcp-project-manager)** - Hierarchical task management (ideas → epics → tasks) with CLI dashboard
 - **[QGIS](https://github.com/jjsantos01/qgis_mcp)** - connects QGIS Desktop to Claude AI through the MCP. This integration enables prompt-assisted project creation, layer loading, code execution, and more.
 - **[Random Number](https://github.com/zazencodes/random-number-mcp)** - Provides LLMs with essential random generation abilities, built entirely on Python's standard library.
 - **[Repo Map](https://github.com.mcas.ms/pdavis68/RepoMapper)** -🐧 🪟 🍎 - An MCP server (and command-line tool) to provide a dynamic map of chat-related files from the repository with their function prototypes and related files in order of relevance. Based on the "Repo Map" functionality in Aider.chat


### PR DESCRIPTION
This PR adds the Project Manager MCP Server to the community servers list.

## About the Server
The Project Manager MCP server enables hierarchical task management with a structured workflow from ideas to epics to tasks, featuring a CLI dashboard for project visualization.

## Features
- Hierarchical task management (ideas → epics → tasks)
- CLI dashboard for project visualization
- NPX-ready deployment
- Compatible with Claude Desktop, Cursor, VS Code + Copilot, Continue.dev

## Repository
- **URL**: https://github.com/croffasia/mcp-project-manager
- **License**: MIT
- **Language**: TypeScript/JavaScript

- [x] Place the newly added server in the right position alphabetically.