### PR TITLE
Add Basecamp MCP Server – Project management integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Apple Shortcuts](https://github.com/recursechat/mcp-server-apple-shortcuts)** - An MCP Server Integration with Apple Shortcuts
 - **[AWS EC2 Pricing](https://github.com/trilogy-group/aws-pricing-mcp)** - Get up-to-date EC2 pricing information with one call. Fast. Powered by a pre-parsed AWS pricing catalogue.
 - **[Backup](https://github.com/hexitex/MCP-Backup-Server)** - Add smart Backup ability to coding agents like Windsurf, Cursor, Cluade Coder, etc
-- **[Basecamp](https://github.com/georgeantonopoulos/MCP_servers/tree/main/Basecamp)** - Integration with Basecamp project management platform for managing projects, to-dos, card tables, documents, and team collaboration
+- **[Basecamp](https://github.com/georgeantonopoulos/Basecamp-MCP-Server)** - Integration with Basecamp project management platform for managing projects, to-dos, card tables, documents, and team collaboration
 - **[BGG MCP](https://github.com/kkjdaniel/bgg-mcp)** - BGG MCP enables AI tools to interact with the BoardGameGeek API.
 - **[BigQuery](https://github.com/LucasHild/mcp-server-bigquery)** (by LucasHild) - BigQuery database integration with schema inspection and query capabilities
 - **[BigQuery](https://github.com/ergut/mcp-bigquery-server)** (by ergut) - Server implementation for Google BigQuery integration that enables direct BigQuery database access and querying capabilities

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Apple Shortcuts](https://github.com/recursechat/mcp-server-apple-shortcuts)** - An MCP Server Integration with Apple Shortcuts
 - **[AWS EC2 Pricing](https://github.com/trilogy-group/aws-pricing-mcp)** - Get up-to-date EC2 pricing information with one call. Fast. Powered by a pre-parsed AWS pricing catalogue.
 - **[Backup](https://github.com/hexitex/MCP-Backup-Server)** - Add smart Backup ability to coding agents like Windsurf, Cursor, Cluade Coder, etc
+- **[Basecamp](https://github.com/georgeantonopoulos/MCP_servers/tree/main/Basecamp)** - Integration with Basecamp project management platform for managing projects, to-dos, card tables, documents, and team collaboration
 - **[BGG MCP](https://github.com/kkjdaniel/bgg-mcp)** - BGG MCP enables AI tools to interact with the BoardGameGeek API.
 - **[BigQuery](https://github.com/LucasHild/mcp-server-bigquery)** (by LucasHild) - BigQuery database integration with schema inspection and query capabilities
 - **[BigQuery](https://github.com/ergut/mcp-bigquery-server)** (by ergut) - Server implementation for Google BigQuery integration that enables direct BigQuery database access and querying capabilities


### PR DESCRIPTION
- [ ✅] Place the newly added server in the right position alphabetically.

- Adds [Basecamp MCP Server](https://github.com/georgeantonopoulos/Basecamp-MCP-Server) to the community servers list, alphabetically under “B”.

- This MCP server provides integration with the Basecamp project management platform, supporting project and to-do management, card tables, documents, and team collaboration features.
 
- Implementation is in Python and self-hostable. 
 
- Works with Cursor and Claude Desktop

Let me know if any further changes are needed, or if it should be moved/retitled. 
Thank you!