### PR TITLE
feat: Add Carbon Voice official ⭐ MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Official integrations are maintained by companies building production ready MCP 
 - **[Buildable](https://github.com/chunkydotdev/bldbl-mcp)** - Official MCP server for Buildable AI-powered development platform. Enables AI assistants to manage tasks, track progress, get project context, and collaborate with humans on software projects.
 - **[Buildkite](https://github.com/buildkite/buildkite-mcp-server)** - Manage [Buildkite](https://buildkite.com) pipelines and builds.
 - **[Campertunity](https://github.com/campertunity/mcp-server)** - Search campgrounds around the world on campertunity, check availability, and provide booking links.
+- **[Carbon Voice](https://github.com/PhononX/cv-mcp-server)** - <img height="20" width="20" src="https://carbonvoice.app/favicon.ico" align="center"/> MCP Server that connects AI Agents to [Carbon Voice](https://getcarbon.app). Create, manage, and interact with voice messages, conversations, direct messages, folders, voice memos, AI actions and more in [Carbon Voice](https://getcarbon.app).
 - **[Chargebee](https://github.com/chargebee/agentkit/tree/main/modelcontextprotocol)** - MCP Server that connects AI agents to [Chargebee platform](https://www.chargebee.com).
 - **[Chart](https://github.com/antvis/mcp-server-chart)** - 🤖 A Model Context Protocol server for generating visual charts using [AntV](https://github.com/antvis).
 - **[Chroma](https://github.com/chroma-core/chroma-mcp)** - Embeddings, vector search, document storage, and full-text search with the open-source AI application database


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description
MCP Server official implementation developed by the Carbon Voice team to enable LLMs to access tools for [Carbon Voice Platform](https://getcarbon.app).

## Motivation and Context
Enable AI assistants and LLMs to seamlessly integrate with Carbon Voice's voice messaging platform, providing comprehensive access to voice conversations, message management, and AI-powered content processing capabilities.

## How Has This Been Tested?
- [x] Each tool on the MCP server has been manually tested within:
  - [x] Claude Desktop
  - [x] Claude AI
  - [x] Cursor

- [X] Place the newly added server in the right position alphabetically.
