### PR TITLE
Add Agent Mindshare MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Official integrations are maintained by companies building production ready MCP 
 
 - **[21st.dev Magic](https://github.com/21st-dev/magic-mcp)** - Create crafted UI components inspired by the best 21st.dev design engineers.
 - **[Adfin](https://github.com/Adfin-Engineering/mcp-server-adfin)** - The only platform you need to get paid - all payments in one place, invoicing and accounting reconciliations with [Adfin](https://www.adfin.com/).
+- **[Agent Mindshare](https://agentmindshare.com)** - Track and monitor AI agent mindshare across platforms - measure brand visibility in AI conversations with [Agent Mindshare](https://agentmindshare.com).
 - **[AgentQL](https://github.com/tinyfish-io/agentql-mcp)** - Enable AI agents to get structured data from unstructured web with [AgentQL](https://www.agentql.com/).
 - **[AgentRPC](https://github.com/agentrpc/agentrpc)** - Connect to any function, any language, across network boundaries using [AgentRPC](https://www.agentrpc.com/).
 - **[Agile Luminary](https://github.com/AgileLuminary/mcp-agile-luminary)** - Simpler Project Management - send [Agile Luminary](https://agileluminary.com) stories straight to your IDE


### PR DESCRIPTION
## Summary
- Added Agent Mindshare to the official MCP servers list
- Agent Mindshare is a remote MCP server for tracking and monitoring AI agent mindshare across platforms
- Helps measure brand visibility in AI conversations

## Details
Agent Mindshare provides tools for:
- Managing prompts and competitors for brands
- Viewing scan results to track AI agent responses
- API endpoint: https://api.agentmindshare.com/mcp

The service requires authentication via API keys and can be connected using:
```bash
claude mcp add --transport http agent-mindshare https://api.agentmindshare.com/mcp --header "Authorization: Bearer <api-key>"
```

🤖 Generated with [Claude Code](https://claude.ai/code)