### PR TITLE
Add Spotify Player (Python) – control Spotify via MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Snowflake](https://github.com/isaacwasserman/mcp-snowflake-server)** - Snowflake database integration with read/write capabilities and insight tracking
 - **[Skyvern](https://github.com/Skyvern-AI/skyvern/tree/main/integrations/mcp)** - MCP Server to let Claude / your AI control the browser
 - **[spm-mcp](https://github.com/simpleswift/spm-mcp)** - iOS Swift Package Manager server written in Swift
+- **[Spotify Player](https://github.com/vsaez/mcp-spotify-player) – Control Spotify playback, queue, volume and playlists from Claude/Cursor via MCP. (Python)
 - **[SQLite](https://github.com/panasenco/mcp-sqlite)** - MCP server for SQLite files. Supports Datasette-compatible metadata!
 - **[Squad AI](https://github.com/the-basilisk-ai/squad-mcp)** – Product‑discovery and strategy platform integration. Create, query and update opportunities, solutions, outcomes, requirements and feedback from any MCP‑aware LLM.
 - **[Storyblok](https://github.com/Kiran1689/storyblok-mcp-server)** - Storyblok MCP server enables your AI assistants to directly access and manage your Storyblok spaces, stories, components, assets, workflows, and more.


### PR DESCRIPTION
This PR adds **Spotify Player** (Python) to the *Community Servers* section.

- Repo: https://github.com/vsaez/mcp-spotify-player
- What it does: Control Spotify playback, queue, volume and playlists from Claude/Cursor via MCP.
- Why useful: Provides a practical, user-facing media integration demonstrating MCP tools end-to-end (search, playback, queue management, diagnostics).

- [ ] Place the newly added server in the right position alphabetically.
