### PR TITLE
Add Django REST Framework MCP to Community Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[dbt-docs](https://github.com/mattijsdp/dbt-docs-mcp)** - MCP server for dbt-core (OSS) users as the official dbt MCP only supports dbt Cloud. Supports project metadata, model and column-level lineage and dbt documentation.
 - **[DeepView MCP](https://github.com/ai-1st/deepview-mcp)** - Enables IDEs like Cursor and Windsurf to analyze large codebases using Gemini's 1M context window.
 - **[DifyWorkflow](https://github.com/gotoolkits/mcp-difyworkflow-server)** - Tools to the query and execute of Dify workflows
+- **[Django REST Framework MCP](https://github.com/zacharypodbela/djangorestframework-mcp)** - Expose Django REST Framework APIs as MCP tools for LLMs and agentic applications
 - **[Docker](https://github.com/QuantGeekDev/docker-mcp)** - Run and manage docker containers, docker compose, and logs
 - **[DynamoDB-Toolbox](https://www.dynamodbtoolbox.com/docs/databases/actions/mcp-toolkit)** - Leverages your Schemas and Access Patterns to interact with your [DynamoDB](https://aws.amazon.com/dynamodb) Database using natural language.
 - **[elisp-dev-mcp](https://github.com/laurynas-biveinis/elisp-dev-mcp)** - elisp (Emacs Lisp) development support tools, running in Emacs.


### PR DESCRIPTION
Django REST Framework MCP enables developers to expose Django REST Framework APIs as MCP tools for LLMs and agentic applications. It provides automatic tool generation from DRF ViewSets with a simple decorator.

The project is in alpha but actively maintained and fills an important gap in the MCP ecosystem for Django developers.
  - **Repository:** https://github.com/zacharypodbela/djangorestframework-mcp
  - **PyPI:** https://pypi.org/project/django-rest-framework-mcp/
  - **License:** MIT

- [X] Place the newly added server in the right position alphabetically.
